### PR TITLE
Fix compatibility with old savings

### DIFF
--- a/Source/Quest/Interop/QuestPart_CityQuest.cs
+++ b/Source/Quest/Interop/QuestPart_CityQuest.cs
@@ -10,8 +10,18 @@ namespace Cities {
 
         public override void ExposeData() {
             base.ExposeData();
+
             Scribe_Collections.Look(ref factions, "factions", LookMode.Reference);
+
+            if (factions == null) {
+                factions = new List<Faction>();
+            }
+
             Scribe_Collections.Look(ref targets, "targets", LookMode.GlobalTargetInfo);
+
+            if (targets == null) {
+                targets = new List<GlobalTargetInfo>();
+            }
         }
 
         public override IEnumerable<Faction> InvolvedFactions => factions;


### PR DESCRIPTION
PR #53 seems to have introduced a missing gizmo issue. I am not able to reproduce the issue locally, but after some analysis, I suspect it is because the `ExposeData` function could set `factions` and `targets` to `null` values for old savings. This PR tries to address this issue by replacing `null` values with empty `List<T>` values.