### PR TITLE
Inherit `CityCommon` comps from `Settlement`

### DIFF
--- a/1.6/Defs/WorldObjects.xml
+++ b/1.6/Defs/WorldObjects.xml
@@ -1,21 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
   
-  <WorldObjectDef Name="CityCommon" Abstract="True">
+  <WorldObjectDef Name="CityCommon" ParentName="Settlement" Abstract="True">
     <worldObjectClass>Cities.City</worldObjectClass>
     <expandingIconTexture>World/WorldObjects/City</expandingIconTexture>
-    <expandingIcon>true</expandingIcon>
-    <expandingIconPriority>10</expandingIconPriority>
-    <canBePlayerHome>true</canBePlayerHome>
-    <comps>
-      <!--<li Class="City.WorldObjectCompProperties_QuestTracker" />-->
-      <li Class="WorldObjectCompProperties_Abandon" />
-      <li Class="WorldObjectCompProperties_TradeRequest" />
-      <li Class="WorldObjectCompProperties_FormCaravan" />
-      <li Class="WorldObjectCompProperties_TimedDetectionRaids" />
-      <!--<li Class="WorldObjectCompProperties_TimedForcedExit" />-->
-      <li Class="WorldObjectCompProperties_EnterCooldown" />
-    </comps>
   </WorldObjectDef>
   
   <WorldObjectDef ParentName="CityCommon">


### PR DESCRIPTION
Certain mods provide quests that require customized world object comps to work properly, some of the comps are injected through XML patching to the `Settlement` def. The city world objects do not inherit from `Settlement`, so they don’t have corresponding comps. This can cause a problem that a quest is accepted by the player, but due to lacking of correspond comps, the player is not able to complete the quest. A concrete example would be the `OA_UrbanConstruction` quest from the `[OA]Ratkin Faction: Oberonia aurea` mod where the player is not able complete the quest by interact with the corresponding city.

This PR attempts to fix this issue by inheriting `CityCommon` comps from `Settlement` along with other default properties.